### PR TITLE
Rectified Instance Name

### DIFF
--- a/Create and Manage Cloud Resources: Challenge Lab
+++ b/Create and Manage Cloud Resources: Challenge Lab
@@ -5,7 +5,7 @@
 
 Task1
 
-gcloud compute instances create nucleus-jumphost \
+gcloud compute instances create nucleus-jumphost-426 \
           --network nucleus-vpc \
           --zone us-east1-b  \
           --machine-type f1-micro  \


### PR DESCRIPTION
Instance Name should be nucleus-jumphost-426 instead of nucleus-jumphost.

![Screenshot (8)](https://user-images.githubusercontent.com/69284082/138702086-0828ea1c-f7f7-4df0-b91d-e59942e9d02f.jpg)
